### PR TITLE
Fix empty track issue

### DIFF
--- a/tests/test_midigen.py
+++ b/tests/test_midigen.py
@@ -31,7 +31,7 @@ class TestMidigen(unittest.TestCase):
 
     def test_set_tempo(self):
         self.midi_gen.set_tempo(90)
-        tempo_msgs = [msg for msg in self.midi_gen._track if msg.type == "set_tempo"]
+        tempo_msgs = [msg for msg in self.midi_gen.track if msg.type == "set_tempo"]
         self.assertEqual(len(tempo_msgs), 1)
         tempo_msg = tempo_msgs[0]
         self.assertEqual(tempo_msg.type, "set_tempo")
@@ -40,7 +40,7 @@ class TestMidigen(unittest.TestCase):
     def test_set_time_signature(self):
         self.midi_gen.set_time_signature(3, 4)
         time_sig_msgs = [
-            msg for msg in self.midi_gen._track if msg.type == "time_signature"
+            msg for msg in self.midi_gen.track if msg.type == "time_signature"
         ]
         self.assertEqual(len(time_sig_msgs), 1)
         time_sig_msg = time_sig_msgs[0]

--- a/tests/test_midigen.py
+++ b/tests/test_midigen.py
@@ -22,6 +22,13 @@ class TestMidigen(unittest.TestCase):
     def test_midi_gen_creation(self):
         self.assertIsNotNone(self.midi_gen)
 
+    def test_tracks(self):
+        self.assertEqual(len(self.midi_gen.midi_file.tracks), 1)
+        midigen_track = self.midi_gen.track
+        midi_file_track = self.midi_gen.midi_file.tracks[0]
+        self.assertEqual(len(midigen_track), len(midi_file_track))
+        self.assertEqual(str(midigen_track), str(midi_file_track))
+
     def test_set_tempo(self):
         self.midi_gen.set_tempo(90)
         tempo_msgs = [msg for msg in self.midi_gen._track if msg.type == "set_tempo"]


### PR DESCRIPTION
## Description

The changes in this pull request fixes empty track issue in `_midi_file` object is `midigen.py`.

Fixes #24

## Changes and Fixes

- [ ] I've added a new feature (provide details).
- [x] I've fixed a bug (give a brief explanation of how it was resolved).
- [ ] I've made a breaking change (describe what was changed).
- [ ] I've made an enhancement to an existing feature (describe what was enhanced).

I've removed **_track** object and used `self.midi_file.tracks[0]` reference to avoid redundant track store.

## How Has This Been Tested?

I've written **test_tracks** function in `test_midigen.py` to test my fix. Other tests also pass successfully.

## Checklist:

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in areas that may be hard for others to understand.
- [x] I have updated the documentation to reflect my changes.
- [x] My changes do not generate new warnings.
- [x] I have added tests that prove my changes are effective.
- [x] New and existing unit tests pass locally with my changes.
